### PR TITLE
Add Cursor.TryFind to hamsterdb-dotnet

### DIFF
--- a/dotnet/hamsterdb-dotnet/Cursor.cs
+++ b/dotnet/hamsterdb-dotnet/Cursor.cs
@@ -355,21 +355,20 @@ namespace Hamster
     }
 
     /// <summary>
-    /// Searches a key and points the Cursor to this key
+    /// Searches for a key and points the Cursor to this key
     /// </summary>
     /// <remarks>
     /// This method wraps the native ham_cursor_find function.
     /// <br />
     /// Searches for an item in the Database and points the Cursor to this
-    /// item. If the item could not be found, the Cursor is not modified.
+    /// item. If the item could not be found, the Cursor is not modified and the return value is null.
     /// <br />
     /// If the key has multiple duplicates, the Cursor is positioned
     /// on the first duplicate.
     /// </remarks>
     /// <param name="key">The key to search for</param>
     /// <param name="flags">The flags, can be zero</param>
-    /// <param name="ok">Set to true if the key was found, false otherwise</param>
-    public byte[] TryFind(ref byte[] key, int flags, out bool ok)
+    public byte[] TryFind(ref byte[] key, int flags)
     {
         int st;
         byte[] record = null;
@@ -377,47 +376,44 @@ namespace Hamster
         {
             st = NativeMethods.CursorFind(handle, ref key, ref record, flags);
         }
-        ok = (st == 0);
         return record;
     }
 
     /// <summary>
-    /// Searches a key and points the Cursor to this key
+    /// Searches for a key and points the Cursor to this key
     /// </summary>
     /// <remarks>
     /// This method wraps the native ham_cursor_find function.
     /// <br />
     /// Searches for an item in the Database and points the Cursor to this
-    /// item. If the item could not be found, the Cursor is not modified.
+    /// item. If the item could not be found, the Cursor is not modified and the return value is null.
     /// <br />
     /// If the key has multiple duplicates, the Cursor is positioned
     /// on the first duplicate.
     /// </remarks>
     /// <param name="key">The key to search for</param>
     /// <param name="flags">The flags, can be zero</param>
-    /// <param name="ok">Set to true if the key was found, false otherwise</param>
-    public byte[] TryFind(byte[] key, int flags, out bool ok)
+    public byte[] TryFind(byte[] key, int flags)
     {
-        return TryFind(ref key, flags, out ok);
+        return TryFind(ref key, flags);
     }
 
     /// <summary>
-    /// Searches a key and points the Cursor to this key
+    /// Searches for a key and points the Cursor to this key
     /// </summary>
     /// <remarks>
     /// This method wraps the native ham_cursor_find function.
     /// <br />
     /// Searches for an item in the Database and points the Cursor to this
-    /// item. If the item could not be found, the Cursor is not modified.
+    /// item. If the item could not be found, the Cursor is not modified and the return value is null.
     /// <br />
     /// If the key has multiple duplicates, the Cursor is positioned
     /// on the first duplicate.
     /// </remarks>
     /// <param name="key">The key to search for</param>
-    /// <param name="ok">Set to true if the key was found, false otherwise</param>
-    public byte[] TryFind(byte[] key, out bool ok)
+    public byte[] TryFind(byte[] key)
     {
-        return TryFind(ref key, 0, out ok);
+        return TryFind(ref key, 0);
     }
 
     /// <summary>

--- a/dotnet/hamsterdb-dotnet/Cursor.cs
+++ b/dotnet/hamsterdb-dotnet/Cursor.cs
@@ -355,6 +355,72 @@ namespace Hamster
     }
 
     /// <summary>
+    /// Searches a key and points the Cursor to this key
+    /// </summary>
+    /// <remarks>
+    /// This method wraps the native ham_cursor_find function.
+    /// <br />
+    /// Searches for an item in the Database and points the Cursor to this
+    /// item. If the item could not be found, the Cursor is not modified.
+    /// <br />
+    /// If the key has multiple duplicates, the Cursor is positioned
+    /// on the first duplicate.
+    /// </remarks>
+    /// <param name="key">The key to search for</param>
+    /// <param name="flags">The flags, can be zero</param>
+    /// <param name="ok">Set to true if the key was found, false otherwise</param>
+    public byte[] TryFind(ref byte[] key, int flags, out bool ok)
+    {
+        int st;
+        byte[] record = null;
+        lock (db)
+        {
+            st = NativeMethods.CursorFind(handle, ref key, ref record, flags);
+        }
+        ok = (st == 0);
+        return record;
+    }
+
+    /// <summary>
+    /// Searches a key and points the Cursor to this key
+    /// </summary>
+    /// <remarks>
+    /// This method wraps the native ham_cursor_find function.
+    /// <br />
+    /// Searches for an item in the Database and points the Cursor to this
+    /// item. If the item could not be found, the Cursor is not modified.
+    /// <br />
+    /// If the key has multiple duplicates, the Cursor is positioned
+    /// on the first duplicate.
+    /// </remarks>
+    /// <param name="key">The key to search for</param>
+    /// <param name="flags">The flags, can be zero</param>
+    /// <param name="ok">Set to true if the key was found, false otherwise</param>
+    public byte[] TryFind(byte[] key, int flags, out bool ok)
+    {
+        return TryFind(ref key, flags, out ok);
+    }
+
+    /// <summary>
+    /// Searches a key and points the Cursor to this key
+    /// </summary>
+    /// <remarks>
+    /// This method wraps the native ham_cursor_find function.
+    /// <br />
+    /// Searches for an item in the Database and points the Cursor to this
+    /// item. If the item could not be found, the Cursor is not modified.
+    /// <br />
+    /// If the key has multiple duplicates, the Cursor is positioned
+    /// on the first duplicate.
+    /// </remarks>
+    /// <param name="key">The key to search for</param>
+    /// <param name="ok">Set to true if the key was found, false otherwise</param>
+    public byte[] TryFind(byte[] key, out bool ok)
+    {
+        return TryFind(ref key, 0, out ok);
+    }
+
+    /// <summary>
     /// Inserts a Database item and points the Cursor to the new item
     /// </summary>
     /// <remarks>

--- a/dotnet/unittests/CursorTest.cs
+++ b/dotnet/unittests/CursorTest.cs
@@ -187,6 +187,29 @@ namespace Unittests
             checkEqual(r2, g);
         }
 
+        private void TryFind()
+        {
+            Cursor c = new Cursor(db);
+            byte[] k1 = new byte[5]; k1[0] = 5;
+            byte[] k2 = new byte[5]; k2[0] = 6;
+            byte[] k3 = new byte[5]; k3[0] = 7;
+            byte[] r1 = new byte[5]; r1[0] = 1;
+            byte[] r2 = new byte[5]; r2[0] = 2;
+            db.Insert(k1, r1);
+            db.Insert(k2, r2);
+            bool ok;
+            c.TryFind(k1, out ok);
+            Assert.IsTrue(ok);
+            byte[] f = c.GetRecord();
+            checkEqual(r1, f);
+            c.TryFind(k2, out ok);
+            Assert.IsTrue(ok);
+            byte[] g = c.GetRecord();
+            checkEqual(r2, g);
+            c.TryFind(k3, out ok);
+            Assert.IsFalse(ok);
+        }
+
         private void Insert() {
             Cursor c = new Cursor(db);
             byte[] q;
@@ -377,6 +400,11 @@ namespace Unittests
             Console.WriteLine("CursorTest.Find");
             SetUp();
             Find();
+            TearDown();
+
+            Console.WriteLine("CursorTest.TryFind");
+            SetUp();
+            TryFind();
             TearDown();
 
             Console.WriteLine("CursorTest.Insert");

--- a/dotnet/unittests/CursorTest.cs
+++ b/dotnet/unittests/CursorTest.cs
@@ -197,17 +197,12 @@ namespace Unittests
             byte[] r2 = new byte[5]; r2[0] = 2;
             db.Insert(k1, r1);
             db.Insert(k2, r2);
-            bool ok;
-            c.TryFind(k1, out ok);
-            Assert.IsTrue(ok);
-            byte[] f = c.GetRecord();
+            var f = c.TryFind(k1);
             checkEqual(r1, f);
-            c.TryFind(k2, out ok);
-            Assert.IsTrue(ok);
-            byte[] g = c.GetRecord();
+            var g = c.TryFind(k2);
             checkEqual(r2, g);
-            c.TryFind(k3, out ok);
-            Assert.IsFalse(ok);
+            var h = c.TryFind(k3);
+            Assert.IsNull(h);
         }
 
         private void Insert() {


### PR DESCRIPTION
Existing method Cursor.Find throws an exception when input key is not
found.  Cursor.TryFind returns a boolean value indicating whether or not
the key was found.