### PR TITLE
Add Cursor.TryMove and corresponding unit test

### DIFF
--- a/dotnet/hamsterdb-dotnet/Cursor.cs
+++ b/dotnet/hamsterdb-dotnet/Cursor.cs
@@ -233,6 +233,28 @@ namespace Hamster
     }
 
     /// <summary>
+    /// Like <see cref="Cursor.Move" />, but returns false only if cursor points to the first (or last) item, and a move to the previous (or next) item was requested
+    /// (i.e., when ham_cursor_move returns <see cref="HamConst.HAM_KEY_NOT_FOUND" />).
+    /// </summary>
+    public bool TryMove(ref byte [] key, ref byte [] record, int flags)
+    {
+        int st;
+        lock (db)
+        {
+            st = NativeMethods.CursorGet(handle, flags, ref key, ref record);
+        }
+        if (st == 0)
+            return true;
+        if (st == HamConst.HAM_KEY_NOT_FOUND)
+        {
+            key = null;
+            record = null;
+            return false;
+        }
+        throw new DatabaseException(st);
+    }
+
+    /// <summary>
     /// Retrieves the Key of the current item
     /// </summary>
     /// <remarks>

--- a/dotnet/hamsterdb-dotnet/HamsterDb-dotnet.xml
+++ b/dotnet/hamsterdb-dotnet/HamsterDb-dotnet.xml
@@ -519,6 +519,12 @@
             <see cref="M:Hamster.Cursor.Move(System.Int32)"/>
             <param name="flags">Additional flags for the movement</param>
         </member>
+        <member name="M:Hamster.Cursor.TryMove(System.Byte[]@,System.Byte[]@,System.Int32)">
+            <summary>
+            Like <see cref="M:Hamster.Cursor.Move(System.Int32)"/>, but returns false only if cursor points to the first (or last) item, and a move to the previous (or next) item was requested
+            (i.e., when ham_cursor_move returns <see cref="F:Hamster.HamConst.HAM_KEY_NOT_FOUND"/>).
+            </summary>
+        </member>
         <member name="M:Hamster.Cursor.GetKey">
             <summary>
             Retrieves the Key of the current item

--- a/dotnet/hamsterdb-dotnet/NativeMethods.cs
+++ b/dotnet/hamsterdb-dotnet/NativeMethods.cs
@@ -291,6 +291,11 @@ namespace Hamster
     static private extern int CursorMoveLow(IntPtr handle,
         IntPtr key, ref RecordStruct record, int flags);
 
+    [DllImport("hamsterdb-2.1.11.dll", EntryPoint = "ham_cursor_move",
+       CallingConvention = CallingConvention.Cdecl)]
+    static private extern int CursorMoveLow(IntPtr handle,
+        ref KeyStruct key, ref RecordStruct record, int flags);
+
     static public int CursorMove(IntPtr handle, int flags) {
       return CursorMoveLow(handle, IntPtr.Zero, IntPtr.Zero, flags);
     }
@@ -319,6 +324,24 @@ namespace Hamster
         return newArray;
       }
       throw new DatabaseException(st);
+    }
+
+    static unsafe public int CursorGet(IntPtr handle, int flags, ref byte[] keyArray, ref byte[] recordArray)
+    {
+        KeyStruct key = new KeyStruct();
+        RecordStruct record = new RecordStruct();
+        int st = CursorMoveLow(handle, ref key, ref record, flags);
+        if (st == 0)
+        {
+            IntPtr keyData = new IntPtr(key.data);
+            keyArray = new byte[key.size];
+            Marshal.Copy(keyData, keyArray, 0, key.size);
+
+            IntPtr recData = new IntPtr(record.data);
+            recordArray = new byte[record.size];
+            Marshal.Copy(recData, recordArray, 0, record.size);
+        }
+        return st;
     }
 
     [DllImport("hamsterdb-2.1.11.dll", EntryPoint = "ham_cursor_overwrite",

--- a/dotnet/unittests/CursorTest.cs
+++ b/dotnet/unittests/CursorTest.cs
@@ -136,6 +136,21 @@ namespace Unittests
             for (int i = 0; i < lhs.Length; i++)
                 Assert.AreEqual(lhs[i], rhs[i]);
         }
+        
+        private void TryMove()
+        {
+            Cursor c = new Cursor(db);
+            byte[] k1 = BitConverter.GetBytes(1UL);
+            byte[] r1 = BitConverter.GetBytes(2UL);
+            db.Insert(k1, r1);
+            byte[] k2 = null, r2 = null;
+            Assert.IsTrue(c.TryMove(ref k2, ref r2, HamConst.HAM_CURSOR_NEXT));
+            checkEqual(k1, k2);
+            checkEqual(r1, r2);
+            Assert.IsFalse(c.TryMove(ref k2, ref r2, HamConst.HAM_CURSOR_NEXT));
+            Assert.IsNull(k2);
+            Assert.IsNull(r2);
+        }
 
         private void GetKey() {
             Cursor c = new Cursor(db);
@@ -380,6 +395,11 @@ namespace Unittests
             Console.WriteLine("CursorTest.MovePrevious");
             SetUp();
             MovePrevious();
+            TearDown();
+
+            Console.WriteLine("CursorTest.TryMove");
+            SetUp();
+            TryMove();
             TearDown();
 
             Console.WriteLine("CursorTest.GetKey");


### PR DESCRIPTION
Cursor.TryMove allows general cursor iteration, returning false when the end (or start) of the database is reached (unlike the other Move variations, which throw an exception).  In addition, both the key and record are returned, to avoid the additional interop overhead of calling Cursor.GetKey and Cursor.GetRecord.  This allows for IEnumerable-like iteration: e.g., while(cursor.TryMove(key, record, HAM_CURSOR_NEXT) { ... }