### PR TITLE
Fix Transaction.Abort, remove unnecessary destructor logic from Cursor and Transaction

### DIFF
--- a/dotnet/hamsterdb-dotnet/Cursor.cs
+++ b/dotnet/hamsterdb-dotnet/Cursor.cs
@@ -49,13 +49,6 @@ namespace Hamster
     }
 
     /// <summary>
-    /// Destructor; closes the Cursor
-    /// </summary>
-    ~Cursor() {
-      Dispose(false);
-    }
-
-    /// <summary>
     /// Creates a new Cursor
     /// </summary>
     ///
@@ -626,16 +619,6 @@ namespace Hamster
     /// </summary>
     /// <see cref="Close" />
     public void Dispose() {
-      Dispose(true);
-      GC.SuppressFinalize(this);
-    }
-
-    /// <summary>
-    /// Closes the Cursor
-    /// </summary>
-    /// <see cref="Close" />
-    protected virtual void Dispose(bool all) {
-      if (all)
         Close();
     }
 

--- a/dotnet/hamsterdb-dotnet/Transaction.cs
+++ b/dotnet/hamsterdb-dotnet/Transaction.cs
@@ -29,13 +29,6 @@ namespace Hamster
     }
 
     /// <summary>
-    /// Destructor; aborts the Transaction
-    /// </summary>
-    ~Transaction() {
-      Dispose(false);
-    }
-
-    /// <summary>
     /// Commits the Transaction
     /// </summary>
     /// <remarks>
@@ -57,7 +50,7 @@ namespace Hamster
     }
 
     /// <summary>
-    /// Aborts the Transaction
+    /// Aborts the Transaction if it has not already been committed or aborted.
     /// </summary>
     /// <remarks>
     /// This method wraps the native ham_txn_abort function.
@@ -67,31 +60,25 @@ namespace Hamster
     /// not closed.
     /// </remarks>
     public void Abort() {
-      int st;
-      lock (env) {
-        st = NativeMethods.TxnAbort(handle, 0);
-      }
-      if (st != 0)
-        throw new DatabaseException(st);
-      handle = IntPtr.Zero;
-      env = null;
+        if (env != null)
+        {
+            int st;
+            lock (env)
+            {
+                st = NativeMethods.TxnAbort(handle, 0);
+            }
+            if (st != 0)
+                throw new DatabaseException(st);
+            handle = IntPtr.Zero;
+            env = null;
+        }
     }
 
     /// <summary>
-    /// Aborts the Transaction
+    /// Aborts the Transaction if it has not already been committed or aborted.
     /// </summary>
     /// <see cref="Abort" />
     public void Dispose() {
-      Dispose(true);
-      GC.SuppressFinalize(this);
-    }
-
-    /// <summary>
-    /// Aborts the Transaction
-    /// </summary>
-    /// <see cref="Abort" />
-    protected virtual void Dispose(bool all) {
-      if (all)
         Abort();
     }
 


### PR DESCRIPTION
Transaction.cs: Check if env is null before aborting transaction.  Note that env is null if the transaction has been committed or aborted.  Without this change, if the Dispose method is called on the Transaction object, it calls Abort, and then abort will throw a null reference exception.

Transaction.cs and Cursor.cs: Removed destructors, as they did nothing but unnecessarily add the object to Finalize queue, which degrades performance.  This then allows removal of one of the Dispose method overloads, since Dispose(bool) is only ever called with Dispose(true).